### PR TITLE
chore(ci): bump up gha version

### DIFF
--- a/.github/workflows/ci-finalize.yml
+++ b/.github/workflows/ci-finalize.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Finalize PR comment
-        uses: LocalStack/setup-localstack/finish@main
+        uses: LocalStack/setup-localstack/finish@v0.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           include-preview: true

--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy Preview
-        uses: LocalStack/setup-localstack/preview@main
+        uses: LocalStack/setup-localstack/ephemeral/startup@v0.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}


### PR DESCRIPTION
# Motivation 
setup-localstack has a new version released which contains some breaking changes with the ephemeral instances.